### PR TITLE
Fix vulnerability with zero-like strings

### DIFF
--- a/index.php
+++ b/index.php
@@ -15,7 +15,7 @@
 		}
 	}
 
-	if ($gPASSW == $tPASS) {
+	if (strcmp($gPASSW, $tPASS) !== 0) {
 		if($_FILES['img']['name']) {
 			if(!$_FILES['img']['error']) {
 				if($_FILES['img']['size'] < (4096000)) { // Also check php.ini for file_uploads and upload_max_filesize


### PR DESCRIPTION
Any zero-like password (0e followed by numbers) would be equal to "0".
Ex: "0e123456789" == "0"

Fixed using strcmp() + strict string comparison.